### PR TITLE
fix: excessive new lines in arrays

### DIFF
--- a/silver-fleece.es.js
+++ b/silver-fleece.es.js
@@ -373,9 +373,9 @@ function stringifyValue(value, indentation, indentString, newlines) {
             return stringifyValue(element, indentation + indentString, indentString, true);
         });
         if (newlines) {
-            return ("[\n".concat(indentation + indentString) +
-                elements.join(",\n".concat(indentation + indentString)) +
-                "\n".concat(indentation, "]"));
+            return ("[".concat(indentation + indentString) +
+                elements.join(",".concat(indentation + indentString)) +
+                "".concat(indentation, "]"));
         }
         return "[ ".concat(elements.join(', '), " ]");
     }
@@ -401,7 +401,7 @@ function patch(str, value) {
         root.type === 'ArrayExpression' && root.elements.length === 0 ||
         root.type === 'ObjectExpression' && root.properties.length === 0);
     return (str.slice(0, root.start) +
-        patchValue(root, value, str, '', indentString, newlines) +
+        patchValue(root, value, str, '\n', indentString, newlines) +
         str.slice(root.end));
 }
 function patchValue(node, value, str, indentation, indentString, newlines) {
@@ -458,7 +458,7 @@ function patchArray(node, value, str, indentation, indentString, newlines) {
             // append new element
             if (newlinesInsideValue) {
                 patched +=
-                    ",\n".concat(indentation + indentString) +
+                    ",".concat(indentation + indentString) +
                         stringifyValue(value[i], indentation, indentString, true);
             }
             else {

--- a/silver-fleece.umd.js
+++ b/silver-fleece.umd.js
@@ -379,9 +379,9 @@
                 return stringifyValue(element, indentation + indentString, indentString, true);
             });
             if (newlines) {
-                return ("[\n".concat(indentation + indentString) +
-                    elements.join(",\n".concat(indentation + indentString)) +
-                    "\n".concat(indentation, "]"));
+                return ("[".concat(indentation + indentString) +
+                    elements.join(",".concat(indentation + indentString)) +
+                    "".concat(indentation, "]"));
             }
             return "[ ".concat(elements.join(', '), " ]");
         }
@@ -407,7 +407,7 @@
             root.type === 'ArrayExpression' && root.elements.length === 0 ||
             root.type === 'ObjectExpression' && root.properties.length === 0);
         return (str.slice(0, root.start) +
-            patchValue(root, value, str, '', indentString, newlines) +
+            patchValue(root, value, str, '\n', indentString, newlines) +
             str.slice(root.end));
     }
     function patchValue(node, value, str, indentation, indentString, newlines) {
@@ -464,7 +464,7 @@
                 // append new element
                 if (newlinesInsideValue) {
                     patched +=
-                        ",\n".concat(indentation + indentString) +
+                        ",".concat(indentation + indentString) +
                             stringifyValue(value[i], indentation, indentString, true);
                 }
                 else {

--- a/src/patch.ts
+++ b/src/patch.ts
@@ -24,7 +24,7 @@ export function patch(str: string, value: any) {
 
 	return (
 		str.slice(0, root.start) +
-		patchValue(root, value, str, '', indentString, newlines) +
+		patchValue(root, value, str, '\n', indentString, newlines) +
 		str.slice(root.end)
 	);
 }
@@ -127,7 +127,7 @@ function patchArray(
 			// append new element
 			if (newlinesInsideValue) {
 				patched +=
-					`,\n${indentation + indentString}` +
+					`,${indentation + indentString}` +
 					stringifyValue(value[i], indentation, indentString, true);
 			} else {
 				patched +=

--- a/src/stringify.ts
+++ b/src/stringify.ts
@@ -40,9 +40,9 @@ export function stringifyValue(
 
 		if (newlines) {
 			return (
-				`[\n${indentation + indentString}` +
-				elements.join(`,\n${indentation + indentString}`) +
-				`\n${indentation}]`
+				`[${indentation + indentString}` +
+				elements.join(`,${indentation + indentString}`) +
+				`${indentation}]`
 			);
 		}
 

--- a/test/test.ts
+++ b/test/test.ts
@@ -647,7 +647,22 @@ describe('silver-fleece', () => {
 			{
 				input: `\u2028`,
 				output: `"\u2028"`
-			}
+			},
+
+			{
+				input: {
+					foo: [
+						"bar",
+						"baz"
+					]
+				},
+				output: `{
+					"foo": [
+						"bar",
+						"baz"
+					]
+				}`
+			},
 		];
 
 		tests.forEach((test, i) => {


### PR DESCRIPTION
Closes #1

The main culprit here was that `indentation` was initiated with different content's for `patch` and `stringify` (`'\n'` vs `''`). After adjusting this, it only needed a few minor tweaks here and there. Now all tests are passing!

Additional notes (not changed by this PR, and not massively important):
- lockfile us behind multiple versions
- i have also update the generated build files, which is the reason why some of the changes appear to be duplicated in the diff. Why are those even commited?
- Same goes for many of the used libs: 
![image](https://github.com/user-attachments/assets/76f1cac0-b6d1-4f9a-94c3-be43753727bc)
